### PR TITLE
chore: upgrade to 1.17.11-exodus.5 for RN 0.85

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-async-storage",
-  "version": "1.17.11-exodus.4",
+  "version": "1.17.11-exodus.5",
   "description": "Asynchronous, persistent, key-value storage system for React Native.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
## Summary

Version bump to `1.17.11-exodus.5` for RN 0.85 upgrade.
Part of [ExodusMovement/exodus-mobile#38221](https://github.com/ExodusMovement/exodus-mobile/issues/38221).

## Audit

<details>
<summary>Audit Report</summary>

# Step 4: Security Audit for react-native-async-storage
Date: 2026-04-23 11:55 UTC
Scan scope: Diff: 3a3101d97282..exodus-rn85
Added lines scanned: 16

## Summary
| Severity | Findings |
|----------|----------|
| CRITICAL | 0 |
| HIGH | 0 |
| MEDIUM | 0 |

## Detailed Findings
No security-relevant patterns detected in the diff.

</details>

## Patches

<details>
<summary>Patch Analysis</summary>

# Step 1: Patch Analysis for react-native-async-storage
Date: 2026-04-23 11:54 UTC

## Summary
- Fork branch: `exodus`
- Merge-base: `3a3101d97282`
- Exodus commits: **12**

## Commit Log
```
79f07b9 v1.17.11-exodus.4
9cdcb86 v1.17.11-exodus.3
d43daaa refactor: don't throw on empty array in multiSet
6f55d54 v1.17.11-exodus.2
6af4dd0 fix: exclude android/test
00d115b v1.17.11-exodus.1
1c44fb3 chore: drop ts & kotlin tests from package
406c5c5 v1.17.11-exodus
2c5829f chore: never fallback to native module
e6f64be chore: cleanup released files
db08245 don't limit db size
b5e5067 rename to @exodus/react-native-async-storage for publishing to npm
```

## Categorized Patches
```
OTHER: v1.17.11-exodus.4
OTHER: v1.17.11-exodus.3
OTHER: refactor: don't throw on empty array in multiSet
OTHER: v1.17.11-exodus.2
BUG_FIX: fix: exclude android/test
OTHER: v1.17.11-exodus.1
PACKAGING: chore: drop ts & kotlin tests from package
OTHER: v1.17.11-exodus
OTHER: chore: never fallback to native module
PACKAGING: chore: cleanup released files
OTHER: don't limit db size
OTHER: rename to @exodus/react-native-async-storage for publishing to npm
```

## Security-Critical Patches
None identified

</details>

## Test Plan

- [ ] Update `src/package.json` in exodus-mobile-upgrade worktree
- [ ] `yarn ios:base` builds
- [ ] `yarn android:base` builds
- [ ] Functional test