### PR TITLE
fix(ios): relax AsyncStorage data protection to allow access while locked

### DIFF
--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -56,6 +56,30 @@ static BOOL RCTAsyncStorageSetExcludedFromBackup(NSString *path, NSNumber *isExc
     return success;
 }
 
+// Relax the data protection class on the storage directory (and its existing contents) to
+// NSFileProtectionCompleteUntilFirstUserAuthentication, so the manifest and value files stay
+// accessible after the first unlock following boot, including while the device is later locked.
+// The default NSFileProtectionComplete class blocks file access whenever the device is locked,
+// which fails when the app is woken in the background while locked (e.g. a geofence or push
+// event) and surfaces as "Failed to write manifest file" / "Could not open the existing manifest".
+static void RCTAsyncStorageSetDataProtection(NSString *directory)
+{
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    NSDictionary *attributes =
+        @{NSFileProtectionKey : NSFileProtectionCompleteUntilFirstUserAuthentication};
+
+    NSError *error = nil;
+    if (![fileManager setAttributes:attributes ofItemAtPath:directory error:&error]) {
+        NSLog(@"Could not set data protection on AsyncStorage dir %@", error);
+        return;
+    }
+
+    for (NSString *item in [fileManager enumeratorAtPath:directory]) {
+        NSString *itemPath = [directory stringByAppendingPathComponent:item];
+        [fileManager setAttributes:attributes ofItemAtPath:itemPath error:NULL];
+    }
+}
+
 static void RCTAppendError(NSDictionary *error, NSMutableArray<NSDictionary *> **errors)
 {
     if (error && errors) {
@@ -275,9 +299,11 @@ static void RCTStorageDirectoryCleanupOld(NSString *oldDirectoryPath)
 
 static void _createStorageDirectory(NSString *storageDirectory, NSError **error)
 {
+    NSDictionary *attributes =
+        @{NSFileProtectionKey : NSFileProtectionCompleteUntilFirstUserAuthentication};
     [[NSFileManager defaultManager] createDirectoryAtPath:storageDirectory
                               withIntermediateDirectories:YES
-                                               attributes:nil
+                                               attributes:attributes
                                                     error:error];
 }
 
@@ -523,6 +549,8 @@ RCT_EXPORT_MODULE()
         }
         RCTAsyncStorageSetExcludedFromBackup(RCTCreateStorageDirectoryPath(RCTStorageDirectory),
                                              isExcludedFromBackup);
+
+        RCTAsyncStorageSetDataProtection(RCTGetStorageDirectory());
 
         NSDictionary *errorOut = nil;
         NSString *serialized = RCTReadFile(RCTCreateStorageDirectoryPath(RCTGetManifestFilePath()),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-async-storage",
-  "version": "1.17.11-exodus.4",
+  "version": "1.17.11-exodus.5",
   "description": "Asynchronous, persistent, key-value storage system for React Native.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
## Summary

Fixes `AsyncStorageError [Failed to write manifest file]` / `Failed to write value` / `Could not open the existing manifest` on iOS, which locks users out of their wallet (exodus-mobile #39598). These have been reported across 6+ releases, predominantly iOS, with accelerating volume.

## Root cause

The storage directory and its files are created without an explicit data protection class, so they inherit `NSFileProtectionComplete` (no file access while the device is locked). The app declares `UIBackgroundModes: remote-notification`, so iOS can wake it in the background while the device is still locked. When that happens, `_writeManifest:` / `_writeEntry:` / `_ensureSetup` cannot read or write the manifest and value files, and the failure propagates to JS as a permanent `AsyncStorageError`, blocking wallet open. The existing code already documents this exact scenario in `_ensureSetup` ("data protection is enabled ... while the device is locked ... started by the system even if the device is locked due to e.g. a geofence event").

## Fix

Set the data protection class to `NSFileProtectionCompleteUntilFirstUserAuthentication`, which keeps the files accessible after the first unlock following boot, including while the device is later locked:

- `_createStorageDirectory` now creates the directory with that protection class, so new installs and newly written files inherit it.
- `_ensureSetup` applies it to the existing storage directory and its current contents once per setup, so existing installs are migrated to the relaxed class the first time the app runs while unlocked.

This is the standard fix for this RNCAsyncStorage data-protection issue and matches newer upstream defaults.

## Security note

This relaxes AsyncStorage at-rest protection from "locked" to "after first unlock". That is acceptable here: secrets are not stored in AsyncStorage, and the directory is already excluded from backup. The trade is intentional, in exchange for not locking users out of their wallet.

## Test plan

- [ ] Native build required (could not be compiled in this environment). Needs device QA: with data protection active, background-wake the app while the device is locked (e.g. push) and confirm manifest/value reads and writes succeed instead of throwing `Failed to write manifest file` / `Could not open the existing manifest`.
- [ ] Verify existing installs (directory created under the old class) recover after one unlocked launch.

## Release

Bumps the package to `1.17.11-exodus.5`. Tag/publish on merge, then bump `@exodus/react-native-async-storage` in exodus-mobile to pick it up.
